### PR TITLE
Prefer linking to system libcec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-- Add missing `links` declaration in crate manifest. This allows downstream crates to avoid compiling vendored `libcec` sources.
+- Add missing `links` declaration in crate manifest.
+- By default, we try to link locally installed `libcec`. See README for details.
 
 ## 1.1.1
 
@@ -16,5 +17,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 1.1.0
 
 - CI improvements
-- Generated `enums.rs` pass new clippy rules 
+- Generated `enums.rs` pass new clippy rules
 - Generated `enums.rs` rely on `enum-repr-derive` 0.2.0 or higher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- Add missing `links` declaration in crate manifest. This allows downstream crates to avoid compiling vendored `libcec` sources.
+
 ## 1.1.1
 
 - CI improvements: updated cross docker images used in build from version 0.1.16 to 0.2.1. This updates the cmake version used to build libcec as well.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cc = '1.0.72'
 
 [features]
 default = []
-use-pkgconfig = ["pkg-config"]
+use-pkgconfig = []
 vendored = ["cmake", "copy_dir"]
 
 [badges.maintenance]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,14 @@ links = 'cec'
 [dependencies]
 
 [build-dependencies]
-cmake = { version = '0.1.45', optional = true }
-copy_dir = { version = '0.1.2', optional = true }
+cmake = '0.1.45'
+copy_dir = '0.1.2'
 pkg-config = '0.3.24'
 cc = '1.0.72'
 
 [features]
 default = []
-vendored = ["cmake", "copy_dir"]
+vendored = []
 
 [badges.maintenance]
 status = 'passively-maintained'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = 'libcec-sys'
-version = "1.1.2-alpha.0"
+version = "2.0.0-alpha.0"
 authors = ['Sami Salonen']
 edition = '2018'
 license = 'GPL-2.0'
@@ -15,11 +15,7 @@ include = [
     '/vendor',
     '/build.rs',
 ]
-keywords = [
-    'libcec',
-    'cec',
-    'hdmi',
-]
+keywords = ['libcec', 'cec', 'hdmi']
 categories = ['external-ffi-bindings']
 homepage = 'https://github.com/ssalonen/libcec-sys'
 repository = 'https://github.com/ssalonen/libcec-sys'
@@ -29,7 +25,15 @@ links = 'cec'
 [dependencies]
 
 [build-dependencies]
-cmake = '0.1.45'
-copy_dir = '0.1.2'
+cmake = { version = '0.1.45', optional = true }
+copy_dir = { version = '0.1.2', optional = true }
+pkg-config = '0.3.24'
+cc = '1.0.72'
+
+[features]
+default = []
+use-pkgconfig = ["pkg-config"]
+vendored = ["cmake", "copy_dir"]
+
 [badges.maintenance]
 status = 'passively-maintained'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ cc = '1.0.72'
 
 [features]
 default = []
-use-pkgconfig = []
 vendored = ["cmake", "copy_dir"]
 
 [badges.maintenance]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ categories = ['external-ffi-bindings']
 homepage = 'https://github.com/ssalonen/libcec-sys'
 repository = 'https://github.com/ssalonen/libcec-sys'
 build = 'build.rs'
+links = 'cec'
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -8,25 +8,10 @@ FFI bindings for the libcec
 
 ## Installation
 
-### Cargo
-
-* Install the rust toolchain in order to have cargo installed by following
-  [this](https://www.rust-lang.org/tools/install) guide.
-* run `cargo install libcec-sys`
-
 ### Linking of libcec
 
-By default, this crate compiles `libcec` from vendored sources. The vendored sources also facilitate re-generating FFI bindings.
-
-Downstream crates can opt to link to system `libcec` by overriding build script as discussed in [cargo documentation](https://doc.rust-lang.org/cargo/reference/build-scripts.html). Minimally, placing the following in workspace's `.cargo/config` will make the resulting crate link to system `cec` library
-
-```toml
-# Replace target-triplet accordingly
-[target.x86_64-unknown-linux-gnu.cec]
-rustc-link-lib = ["cec"]
-```
-
-This will mean that compilation of vendored `libcec` sources in `libcec-sys` is skipped, and build will be generally faster.
+By default, this crate tried to link to `libcec` version >= 4.0.0. `pkg-config` is always preferred when available.
+Alternatively, one can use vendored sources by disabling the default features and enabling `vendored` feature.
 
 ## License
 
@@ -48,6 +33,7 @@ for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Releasing
 
 ```cargo release --skip-publish``` and let the github CD pipeline do the rest.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ FFI bindings for the libcec
 ### Linking of libcec
 
 By default, this crate tried to link to `libcec` version >= 4.0.0. `pkg-config` is always preferred when available.
-Alternatively, one can use vendored sources by enabling `vendored` feature.
+Alternatively, one can force the use of vendored sources by enabling `vendored` feature.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ FFI bindings for the libcec
 ### Linking of libcec
 
 By default, this crate tried to link to `libcec` version >= 4.0.0. `pkg-config` is always preferred when available.
-Alternatively, one can use vendored sources by disabling the default features and enabling `vendored` feature.
+Alternatively, one can use vendored sources by enabling `vendored` feature.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ FFI bindings for the libcec
   [this](https://www.rust-lang.org/tools/install) guide.
 * run `cargo install libcec-sys`
 
+### Linking of libcec
+
+By default, this crate compiles `libcec` from vendored sources. The vendored sources also facilitate re-generating FFI bindings.
+
+Downstream crates can opt to link to system `libcec` by overriding build script as discussed in [cargo documentation](https://doc.rust-lang.org/cargo/reference/build-scripts.html). Minimally, placing the following in workspace's `.cargo/config` will make the resulting crate link to system `cec` library
+
+```toml
+# Replace target-triplet accordingly
+[target.x86_64-unknown-linux-gnu.cec]
+rustc-link-lib = ["cec"]
+```
+
+This will mean that compilation of vendored `libcec` sources in `libcec-sys` is skipped, and build will be generally faster.
+
 ## License
 
 Licensed under GNU General Public License version 2, ([LICENSE](LICENSE) or [https://opensource.org/licenses/GPL-2.0](https://opensource.org/licenses/GPL-2.0))

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-use cc;
 use copy_dir::copy_dir;
 use std::env;
 use std::fs;

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,6 @@ use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use pkg_config;
-
 const MIN_LIBCEC_VERSION: &str = "4.0.0";
 
 const P8_PLATFORM_DIR_ENV: &str = "p8-platform_DIR";
@@ -121,11 +119,12 @@ fn main() {
         compile_vendored();
     }
     // Try discovery using pkg-config
-    else if let Ok(_) = pkg_config::Config::new()
+    else if pkg_config::Config::new()
         .atleast_version(MIN_LIBCEC_VERSION)
         .probe("libcec")
+        .is_ok()
     {
-        return;
+        // pkg-config found the package and the parameters will be used for linking
     }
     // Try smoke-test build using -lcec. If unsuccessful, revert to vendored sources
     else if libcec_installed_smoke_test() {

--- a/build.rs
+++ b/build.rs
@@ -142,10 +142,9 @@ fn main() {
         return;
     }
     // Try discovery using pkg-config
-    if let Ok(pkg_config_ok) = pkg_config::Config::new()
+    if let Ok(_) = pkg_config::Config::new()
         .atleast_version(MIN_LIBCEC_VERSION)
         .probe("cec")
-        .unwrap()
     {
         return;
     }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,4 @@
-#![allow(unused_imports, dead_code)] // due to cfg(feature)
-
 use cc;
-#[cfg(feature = "vendored")]
 use copy_dir::copy_dir;
 use std::env;
 use std::fs;
@@ -19,7 +16,6 @@ const LIBCEC_BUILD: &str = "libcec_build";
 const PLATFORM_BUILD: &str = "platform_build";
 const LIBCEC_SRC: &str = "vendor";
 
-#[cfg(feature = "vendored")]
 fn prepare_vendored_build(dst: &Path) {
     let dst_src = dst.join(LIBCEC_SRC);
     if dst_src.exists() && dst_src.is_dir() {
@@ -46,12 +42,7 @@ fn prepare_vendored_build(dst: &Path) {
         .write_all(b"set(LIB_INFO \"\")")
         .unwrap_or_else(|_| panic!("Error writing {}", &set_build_info_path.to_string_lossy()));
 }
-#[cfg(not(feature = "vendored"))]
-fn prepare_vendored_build(_: &Path) {
-    unimplemented!();
-}
 
-#[cfg(feature = "vendored")]
 fn compile_vendored_platform(dst: &Path) {
     let platform_build = dst.join(PLATFORM_BUILD);
     // let tmp_libcec_src = dst.join(LIBCEC_SRC);
@@ -66,12 +57,7 @@ fn compile_vendored_platform(dst: &Path) {
         .status()
         .expect("failed to make libcec platform!");
 }
-#[cfg(not(feature = "vendored"))]
-fn compile_vendored_platform(_: &Path) {
-    unimplemented!();
-}
 
-#[cfg(feature = "vendored")]
 fn compile_vendored_libcec(dst: &Path) {
     let platform_build = dst.join(PLATFORM_BUILD);
     let libcec_build = dst.join(LIBCEC_BUILD);
@@ -86,11 +72,6 @@ fn compile_vendored_libcec(dst: &Path) {
         .env(P8_PLATFORM_DIR_ENV, &platform_build)
         .status()
         .expect("failed to make libcec!");
-}
-
-#[cfg(not(feature = "vendored"))]
-fn compile_vendored_libcec(_: &Path) {
-    unimplemented!();
 }
 
 fn libcec_installed_smoke_test() -> bool {
@@ -143,7 +124,7 @@ fn main() {
     // Try discovery using pkg-config
     else if let Ok(_) = pkg_config::Config::new()
         .atleast_version(MIN_LIBCEC_VERSION)
-        .probe("cec")
+        .probe("libcec")
     {
         return;
     }

--- a/build.rs
+++ b/build.rs
@@ -139,10 +139,9 @@ fn main() {
     if cfg!(feature = "vendored") {
         // vendored build explicitly requested. Build vendored sources
         compile_vendored();
-        return;
     }
     // Try discovery using pkg-config
-    if let Ok(_) = pkg_config::Config::new()
+    else if let Ok(_) = pkg_config::Config::new()
         .atleast_version(MIN_LIBCEC_VERSION)
         .probe("cec")
     {

--- a/src/smoke.c
+++ b/src/smoke.c
@@ -1,0 +1,6 @@
+#include <cecc.h>
+
+int main()
+{
+    return (int)libcec_initialise;
+}


### PR DESCRIPTION
Compilation of vendored libcec can be skipped.

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/libcec-sys/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/libcec-sys/blob/master/CHANGELOG.md
-->
