### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 on:
+    workflow_dispatch:
     push:
         branches:
             - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             - name: Checkout libcec-sys submodules
               run: git -c "url.https://github.com/.insteadOf=git@github.com:" submodule update --init --recursive
             - name: Apt-get update
-              if: runner.os == "Linux"
+              if: runner.os == 'Linux'
               run: sudo apt-get update -yq
             - name: Installing Rust toolchain
               uses: actions-rs/toolchain@v1
@@ -150,11 +150,11 @@ jobs:
               name: Install libcec(-dev) and build dependencies
               run: sudo apt-get install -yq libudev-dev libp8-platform2 libp8-platform-dev ${{ matrix.job.libcec }} ${{ matrix.job.libcec-dev }}
             # additional build dependencies for non-cross builds with vendored libcec sources
-            - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == "Linux" }}
+            - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == 'Linux' }}
               name: Install libudev-dev for non-cross vendored builds as libcec build dependency
               run: sudo apt-get install -yq libudev-dev
             # setup developer command prompt for Windows
-            - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == "Windows" }}
+            - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == 'Windows' }}
               name: Setup developer command prompt
               uses: ilammy/msvc-dev-cmd@v1
             # pkg-config install/remove
@@ -164,6 +164,13 @@ jobs:
             - if: ${{ !startsWith(matrix.job.libcec, 'vendored') && !matrix.job.pkg-config }}
               name: Remove pkg-config
               run: sudo apt-get remove -yq pkg-config
+            # install Python with debug binaries for Windows
+            - if: runner.os == 'Windows'
+              name: Install python 3.10.5 with debug binaries
+              run: |
+                  $arch = '${{ runner.arch }}' -eq 'X86' ? "" : "-amd64"
+                  curl -o python-3.10.5$arch.exe https://www.python.org/ftp/python/3.10.5/python-3.10.5$arch.exe
+                  Start-Process -FilePath "python-3.10.5$arch.exe" -ArgumentList "/quiet Include_debug=1 PrependPath=1 InstallAllUsers=0" -Verb runas -Wait
             - name: Cargo test
               env:
                   EXPECTED_LIBCEC_VERSION_MAJOR: ${{ matrix.job.expected_libcec_abi }}
@@ -174,7 +181,7 @@ jobs:
                   command: test
                   use-cross: ${{ matrix.job.use-cross }}
                   toolchain: ${{ matrix.rust }}
-                  args: --target ${{ matrix.job.target }} --release -vv
+                  args: --target ${{ matrix.job.target }} -vv
 
     rustfmt:
         name: Rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
               name: Remove pkg-config
               run: sudo apt-get remove -yq pkg-config
             # install Python with debug binaries for Windows
+            # Github Workflow runners do not package debug binaries by default
             - if: runner.os == 'Windows'
               name: Install python 3.10.5 with debug binaries
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
             matrix:
                 rust: [stable]
                 job:
+                    - os: windows-latest
+                      target: x86_64-pc-windows-msvc
+                      use-cross: false
+                      libcec: vendored-libcec
+                      expected_libcec_abi: 6
+                    - os: windows-latest
+                      target: i686-pc-windows-msvc
+                      use-cross: false
+                      libcec: vendored-libcec
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: aarch64-unknown-linux-gnu
                       use-cross: true
@@ -107,6 +117,7 @@ jobs:
             - name: Checkout libcec-sys submodules
               run: git -c "url.https://github.com/.insteadOf=git@github.com:" submodule update --init --recursive
             - name: Apt-get update
+              if: runner.os == "Linux"
               run: sudo apt-get update -yq
             - name: Installing Rust toolchain
               uses: actions-rs/toolchain@v1
@@ -138,9 +149,13 @@ jobs:
               name: Install libcec(-dev) and build dependencies
               run: sudo apt-get install -yq libudev-dev libp8-platform2 libp8-platform-dev ${{ matrix.job.libcec }} ${{ matrix.job.libcec-dev }}
             # additional build dependencies for non-cross builds with vendored libcec sources
-            - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross }}
+            - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == "Linux" }}
               name: Install libudev-dev for non-cross vendored builds as libcec build dependency
               run: sudo apt-get install -yq libudev-dev
+            # setup developer command prompt for Windows
+            - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == "Windows" }}
+              name: Setup developer command prompt
+              uses: ilammy/msvc-dev-cmd@v1
             # pkg-config install/remove
             - if: ${{ !startsWith(matrix.job.libcec, 'vendored') && matrix.job.pkg-config }}
               name: Install pkg-config for utilizing libcec from apt build dependency
@@ -158,7 +173,7 @@ jobs:
                   command: test
                   use-cross: ${{ matrix.job.use-cross }}
                   toolchain: ${{ matrix.rust }}
-                  args: --target ${{ matrix.job.target }} -vv
+                  args: --target ${{ matrix.job.target }} --release -vv
 
     rustfmt:
         name: Rustfmt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- Support for Windows
 - Build script:
     - Fixes for "smoke testing" (detecting libcec installation with `pkg-config`)
     - Fixes for recompilation (only compile if there is a change)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,20 @@ This crate works with `libcec` v4.x, v5.x and v6.x (latest version as time of wr
 
 Alternatively, one can the decide to skip logic above and force the use of vendored sources by enabling `vendored` feature.
 
-For most convenient build process, it is recommended to install `pkg-config`, `libcec-dev` (headers and pkg-config configuration), `libcec6` (dynamic library), `p8-platform-dev` and `p8-platform` from your package distribution before installing this crate. Exact package names vary between distributions and package managers.
+The crate is tested mainly with Linux and Windows but could work with other platforms as well. PRs welcome.
 
-The crate is tested mainly with linux but could work with other platforms as well. PRs welcome.
+### Linux
+On Linux, for most convenient build process, it is recommended to install `pkg-config`, `libcec-dev` (headers and pkg-config configuration), `libcec6` (dynamic library), `p8-platform-dev` and `p8-platform` from your package distribution before installing this crate. Exact package names vary between distributions and package managers.
+
+### Windows
+On Windows, it is recommended to install `libcec` via the [installer](https://github.com/Pulse-Eight/libcec/releases/latest) and add `cec.dll` to the `PATH` environment variable.
+
+For a vendored build, `libcec-sys` will dynamically link to the compiled `cec.dll`. This means you must package your standalone executable with the compiled dynamic library.
+
+#### Vendored Build Prerequisites:
+- Visual Studio 2019 w/ `Desktop Development with C++` and `Universal Windows Platform development`
+- CMake 3.12+
+- Python 3.6+ with Debug Binaries
 
 ## License
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -100,7 +100,7 @@ fn libcec_installed_smoke_test() -> Result<CecVersion, ()> {
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     println!("\n\nUsing 'smoke test' to find out if libcec is installed");
     for abi in CEC_MAJOR_VERSIONS {
-        let mut cc_cmd =  compiler.to_command();
+        let mut cc_cmd = compiler.to_command();
         println!("\n\nSmoke testing with libcec major {}", abi.major());
         if cfg!(windows) {
             cc_cmd

--- a/build/build.rs
+++ b/build/build.rs
@@ -97,11 +97,10 @@ fn compile_vendored_libcec(dst: &Path) {
 
 fn libcec_installed_smoke_test() -> Result<CecVersion, ()> {
     let compiler = cc::Build::new().get_compiler();
-    let compiler_path = compiler.path();
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     println!("\n\nUsing 'smoke test' to find out if libcec is installed");
     for abi in CEC_MAJOR_VERSIONS {
-        let mut cc_cmd = Command::new(compiler_path);
+        let mut cc_cmd =  compiler.to_command();
         println!("\n\nSmoke testing with libcec major {}", abi.major());
         if cfg!(windows) {
             cc_cmd

--- a/build/build.rs
+++ b/build/build.rs
@@ -174,7 +174,7 @@ fn compile_vendored() {
             .arg("Release")
             .arg("2019")
             .arg(dst.join(LIBCEC_BUILD))
-            .arg("vs")
+            .arg("nmake")
             .status()
             .expect("failed to build libcec!");
         println!(

--- a/build/build.rs
+++ b/build/build.rs
@@ -175,8 +175,16 @@ fn compile_vendored() {
         Command::new("cmd")
             .arg("/C")
             .arg(dst.join(LIBCEC_SRC).join("windows").join("build-lib.cmd"))
-            .arg("amd64")
-            .arg("Release")
+            .arg(if cfg!(target_pointer_width = "64") {
+                "amd64"
+            } else {
+                "x86"
+            })
+            .arg(if cfg!(debug_assertions) {
+                "Debug"
+            } else {
+                "Release"
+            })
             .arg("2019")
             .arg(dst.join(LIBCEC_BUILD))
             .arg("nmake")
@@ -222,6 +230,7 @@ fn main() {
     println!("cargo:rerun-if-changed=vendor");
     println!("cargo:rerun-if-env-changed=LD_LIBRARY_PATH");
     println!("cargo:rerun-if-env-changed=LDFLAGS");
+    println!("cargo:rerun-if-env-changed=INCLUDE");
     println!("cargo:rerun-if-env-changed=PATH");
     println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
     println!("cargo:rerun-if-env-changed=CC");

--- a/build/build.rs
+++ b/build/build.rs
@@ -102,14 +102,13 @@ fn libcec_installed_smoke_test() -> Result<CecVersion, ()> {
     for abi in CEC_MAJOR_VERSIONS {
         let mut cc_cmd = compiler.to_command();
         println!("\n\nSmoke testing with libcec major {}", abi.major());
+        cc_cmd.arg(format!("build/smoke_abi{}.c", abi.major()))
         if cfg!(windows) {
             cc_cmd
-                .arg(format!("build/smoke_abi{}.c", abi.major()))
                 .arg("/Fe:")
                 .arg(dst.join(format!("smoke_abi{}_out.exe", abi.major())));
         } else {
             cc_cmd
-                .arg(format!("build/smoke_abi{}.c", abi.major()))
                 .arg("-o")
                 .arg(dst.join(format!("smoke_abi{}_out", abi.major())))
                 .arg("-lcec");

--- a/build/build.rs
+++ b/build/build.rs
@@ -13,7 +13,6 @@ const LIBCEC_BUILD: &str = "libcec_build";
 const PLATFORM_BUILD: &str = "platform_build";
 const LIBCEC_SRC: &str = "vendor";
 
-#[cfg(target_os = "windows")]
 const ARCHITECTURE: &str = if cfg!(target_pointer_width = "64") {
     "amd64"
 } else {
@@ -66,6 +65,7 @@ fn prepare_vendored_build(dst: &Path) {
         .unwrap_or_else(|_| panic!("Error writing {}", &set_build_info_path.to_string_lossy()));
 }
 
+#[cfg(not(target_os = "windows"))]
 fn compile_vendored_platform(dst: &Path) {
     let platform_build = dst.join(PLATFORM_BUILD);
     // let tmp_libcec_src = dst.join(LIBCEC_SRC);
@@ -195,7 +195,8 @@ fn compile_vendored() {
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     println!("Building libcec from local source");
     prepare_vendored_build(&dst);
-    if cfg!(linux) {
+    #[cfg(not(target_os = "windows"))]
+    {
         compile_vendored_platform(&dst);
     }
     compile_vendored_libcec(&dst);

--- a/build/build.rs
+++ b/build/build.rs
@@ -195,21 +195,17 @@ fn compile_vendored() {
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     println!("Building libcec from local source");
     prepare_vendored_build(&dst);
-    if cfg!(windows) {
-        compile_vendored_libcec(&dst);
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join(LIBCEC_BUILD).join(ARCHITECTURE).display()
-        );
-    } else {
+    if cfg!(linux) {
         compile_vendored_platform(&dst);
-        compile_vendored_libcec(&dst);
-        println!(
-            "cargo:rustc-link-search=native={}",
-            dst.join(LIBCEC_BUILD).join("lib").display(),
-        );
     }
+    compile_vendored_libcec(&dst);
 
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dst.join(LIBCEC_BUILD)
+            .join(if cfg!(windows) { ARCHITECTURE } else { "lib" })
+            .display()
+    );
     println!("cargo:rustc-link-lib=cec");
 }
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -235,6 +235,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CFLAGS");
     println!("cargo:rerun-if-env-changed=CXX");
     println!("cargo:rerun-if-env-changed=CXXFLAGS");
+    println!("cargo:rerun-if-env-changed=LIB");
+    println!("cargo:rerun-if-env-changed=CL");
+    println!("cargo:rerun-if-env-changed=_CL_");
 
     // Try discovery using pkg-config
     if !cfg!(feature = "vendored") {

--- a/build/build.rs
+++ b/build/build.rs
@@ -104,7 +104,7 @@ fn libcec_installed_smoke_test() -> Result<CecVersion, ()> {
         if cfg!(windows) {
             cc_cmd
                 .arg(format!("build/smoke_abi{}.c", abi.major()))
-                .arg("/Fe")
+                .arg("/Fe:")
                 .arg(dst.join("smoke_out.exe"));
         } else {
             cc_cmd


### PR DESCRIPTION
## Closes #13 
Support for Windows is fairly straightforward and libcec takes care of most of the work via their batch files.

### Prerequisites:
* Visual Studio 2019 w/ Desktop Development with C++ and Universal Windows Platform development
* CMake 3.12+
* Python 3.6+ with Debug Binaries (not sure the exact min version, took it from docs)
* **and possibly more**

### TODO
- [x] #14.
- [x] Initialize compiler env variables before smoke test.
- [x] Automatically choose between `Release` and `Debug` build.
- [x] Find platform type.
- [x] Add to CI.
- [x] Add to README.
- [x] Add to CHANGELOG.

For now, I've hardcoded a few parameters just for testing.