### PR TITLE
CI: fix smoke test building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+- build script: fixes for "smoke testing" (detecting libcec installation with `pkg-config`)
+
 ## [3.0.0]
 
 - Support for libcec major versions 4, 5 and 6

--- a/build/build.rs
+++ b/build/build.rs
@@ -98,13 +98,15 @@ fn compile_vendored_libcec(dst: &Path) {
 fn libcec_installed_smoke_test() -> Result<CecVersion, ()> {
     let compiler = cc::Build::new().get_compiler();
     let compiler_path = compiler.path();
-    let mut cc_cmd = Command::new(compiler_path);
     let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    println!("\n\nUsing 'smoke test' to find out if libcec is installed");
     for abi in CEC_MAJOR_VERSIONS {
+        let mut cc_cmd = Command::new(compiler_path);
+        println!("\n\nSmoke testing with libcec major {}", abi.major());
         cc_cmd
             .arg(format!("build/smoke_abi{}.c", abi.major()))
             .arg("-o")
-            .arg(dst.join("smoke_out"))
+            .arg(dst.join(format!("smoke_abi{}_out", abi.major())))
             .arg("-lcec");
         if let Ok(status) = cc_cmd.status() {
             if status.success() {
@@ -118,7 +120,9 @@ fn libcec_installed_smoke_test() -> Result<CecVersion, ()> {
 }
 
 fn libcec_installed_pkg_config() -> Result<CecVersion, ()> {
+    println!("\n\nUsing pkg-config to find out if libcec is installed");
     for abi in CEC_MAJOR_VERSIONS {
+        println!("\n\npkg-config with libcec major {}", abi.major());
         let pkg_config_result = pkg_config::Config::new()
             .atleast_version(&abi.major().to_string())
             .probe("libcec");
@@ -137,6 +141,7 @@ fn libcec_installed_pkg_config() -> Result<CecVersion, ()> {
 }
 
 fn compile_vendored() {
+    println!("\n\nBuilding vendored libcec");
     println!("cargo:lib_vendored=true");
 
     let cmakelists = format!("{}/CMakeLists.txt", LIBCEC_SRC);

--- a/build/smoke_abi4.c
+++ b/build/smoke_abi4.c
@@ -3,6 +3,7 @@
 
 int main()
 {
-    _Static_assert(CEC_LIB_VERSION_MAJOR == 4, "LIBCEC != v4.x.y");
+    _Static_assert(CEC_LIB_VERSION_MAJOR == 4, 
+        "libcec major version is " CEC_LIB_VERSION_MAJOR_STR ", not as expected (4)");
     return (intptr_t)libcec_initialise;
 }

--- a/build/smoke_abi5.c
+++ b/build/smoke_abi5.c
@@ -3,6 +3,7 @@
 
 int main()
 {
-    _Static_assert(CEC_LIB_VERSION_MAJOR == 5, "LIBCEC != v5.x.y");
+    _Static_assert(CEC_LIB_VERSION_MAJOR == 5, 
+        "libcec major version is " CEC_LIB_VERSION_MAJOR_STR ", not as expected (5)");
     return (intptr_t)libcec_initialise;
 }

--- a/build/smoke_abi6.c
+++ b/build/smoke_abi6.c
@@ -3,6 +3,7 @@
 
 int main()
 {
-    _Static_assert(CEC_LIB_VERSION_MAJOR == 6, "LIBCEC != v6.x.y");
+    _Static_assert(CEC_LIB_VERSION_MAJOR == 6, 
+        "libcec major version is " CEC_LIB_VERSION_MAJOR_STR ", not as expected (6)");
     return (intptr_t)libcec_initialise;
 }


### PR DESCRIPTION
* cc_cmd was reused between runs, leading to unexpected results
* Improved build.rs debug logging

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/libcec-sys/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/libcec-sys/blob/master/CHANGELOG.md
-->
