### PR TITLE
Fix libcec6 cmake vendored

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Important that we do not run cross so package install shows up
                       libcec: libcec4
-                      libcec-dev: libcec-dev
+                      libcec-dev: libcec4-dev
                       pkg-config: false
                       expected_libcec_abi: 4
                       additional_env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,47 +19,47 @@ jobs:
                       target: aarch64-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: i686-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: arm-unknown-linux-gnueabi
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: armv7-unknown-linux-gnueabihf
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: mips-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: mips64-unknown-linux-gnuabi64
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: mips64el-unknown-linux-gnuabi64
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: mipsel-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     - os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Not run in cross so that EXPECTED_LIBCEC_VERSION_MAJOR shows inside the test
                       libcec: vendored-libcec
-                      expected_libcec_abi: 4
+                      expected_libcec_abi: 6
                     #
                     # libcec discovery with pkg config
                     #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Important that we do not run cross so package install shows up
                       libcec: libcec4
-                      libcec-dev: libcec4-dev
+                      libcec-dev: libcec-dev=4.0.4+dfsg1-4ubuntu3
                       pkg-config: false
                       expected_libcec_abi: 4
                       additional_env:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 FFI bindings for the libcec
 ## Linking to system libcec
 
-This crate works with `libcec` v4.x, v5.x and v6.x (latest version as time of writing). During the build we try to find `libcec` system library installation using `pkg-config` and compilation using default C compiler (`cc` crate). As a fallback, vendored `libcec` (v4.x) is used during the build.
+This crate works with `libcec` v4.x, v5.x and v6.x (latest version as time of writing). During the build we try to find `libcec` system library installation using `pkg-config` and compilation using default C compiler (`cc` crate). As a fallback, vendored `libcec` (v6.x) is used during the build.
 
 Alternatively, one can the decide to skip logic above and force the use of vendored sources by enabling `vendored` feature.
 
@@ -19,7 +19,7 @@ The crate is tested mainly with linux but could work with other platforms as wel
 
 Licensed under GNU General Public License version 2, ([LICENSE](LICENSE) or [https://opensource.org/licenses/GPL-2.0](https://opensource.org/licenses/GPL-2.0))
 
-The CI/CD setup in `.github/` is based on [rust-github/template](https://github.com/rust-github/template), and therefore licensed under  either of
+The CI/CD setup in `.github/` is based on [rust-github/template](https://github.com/rust-github/template), and therefore licensed under either of
 
 * Apache License, Version 2.0
    ([LICENSE-CI-APACHE](LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0))

--- a/build/build.rs
+++ b/build/build.rs
@@ -8,7 +8,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const P8_PLATFORM_DIR_ENV: &str = "p8-platform_DIR";
+const P8_PLATFORM_ROOT_ENV: &str = "p8-platform_ROOT";
 const LIBCEC_BUILD: &str = "libcec_build";
 const PLATFORM_BUILD: &str = "platform_build";
 const LIBCEC_SRC: &str = "vendor";
@@ -66,13 +66,13 @@ fn compile_vendored_platform(dst: &Path) {
     println!("cmake platform");
     cmake::Config::new(dst.join(LIBCEC_SRC).join("src").join("platform"))
         .out_dir(&platform_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .build();
 
     println!("make platform");
     Command::new("make")
         .current_dir(&platform_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .status()
         .expect("failed to make libcec platform!");
 }
@@ -84,13 +84,13 @@ fn compile_vendored_libcec(dst: &Path) {
     println!("cmake libcec");
     cmake::Config::new(&dst.join(LIBCEC_SRC))
         .out_dir(&libcec_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .build();
 
     println!("make libcec");
     Command::new("make")
         .current_dir(&libcec_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .status()
         .expect("failed to make libcec!");
 }


### PR DESCRIPTION
https://github.com/ssalonen/libcec-sys/pull/14#issuecomment-1191939994 from @ok-nick 

> I ran the CI on my repo and it seems there are a few issues compiling vendored libcec v6. https://github.com/ok-nick/libcec-sys/runs/7457424524?check_suite_focus=true#step:12:547

https://cmake.org/cmake/help/latest/command/find_package.html
https://cmake.org/cmake/help/latest/policy/CMP0074.html#policy:CMP0074

`_ROOT` env variable should be safe to rely as libcec6 imposes `cmake_minimum_required(VERSION 3.12.0)`

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/libcec-sys/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/libcec-sys/blob/master/CHANGELOG.md
-->
