### PR TITLE
Recompilation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
-- build script: fixes for "smoke testing" (detecting libcec installation with `pkg-config`)
+- Build script:
+    - Fixes for "smoke testing" (detecting libcec installation with `pkg-config`)
+    - Fixes for recompilation (only compile if there is a change)
 
 ## [3.0.0]
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -191,7 +191,7 @@ fn parse_vendored_libcec_major_version(cmakelists: &Path) -> u32 {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=build/build.rs");
+    println!("cargo:rerun-if-changed=build");
     // Try discovery using pkg-config
     if !cfg!(feature = "vendored") {
         let version = libcec_installed_pkg_config();

--- a/build/build.rs
+++ b/build/build.rs
@@ -191,7 +191,7 @@ fn parse_vendored_libcec_major_version(cmakelists: &Path) -> u32 {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build/build.rs");
     // Try discovery using pkg-config
     if !cfg!(feature = "vendored") {
         let version = libcec_installed_pkg_config();

--- a/build/build.rs
+++ b/build/build.rs
@@ -192,6 +192,16 @@ fn parse_vendored_libcec_major_version(cmakelists: &Path) -> u32 {
 
 fn main() {
     println!("cargo:rerun-if-changed=build");
+    println!("cargo:rerun-if-changed=vendor");
+    println!("cargo:rerun-if-env-changed=LD_LIBRARY_PATH");
+    println!("cargo:rerun-if-env-changed=LDFLAGS");
+    println!("cargo:rerun-if-env-changed=PATH");
+    println!("cargo:rerun-if-env-changed=PKG_CONFIG_PATH");
+    println!("cargo:rerun-if-env-changed=CC");
+    println!("cargo:rerun-if-env-changed=CFLAGS");
+    println!("cargo:rerun-if-env-changed=CXX");
+    println!("cargo:rerun-if-env-changed=CXXFLAGS");
+
     // Try discovery using pkg-config
     if !cfg!(feature = "vendored") {
         let version = libcec_installed_pkg_config();


### PR DESCRIPTION
`libcec-sys` recompiles every time due to an incorrect path to the build script for `rerun-if-changed`. This should fix it.