### PR TITLE
CI: use ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
                   set -e
                   # introduce Ubuntu 20.04 (Focal Fossa) repos as well for easy libcec4 installation
                   sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse" >> /etc/apt/sources.list'
-                  sudo apt-get update
                   sudo apt-get install -yq libudev-dev libp8-platform2 libp8-platform-dev
 
                   apt show '${{ matrix.job.libcec }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
             - if: ${{ !startsWith(matrix.job.libcec, 'vendored')  && runner.os == 'Linux' }}
               name: Install libcec(-dev) and build dependencies
               run: |
-                  set -e
+                  set -ex
                   # introduce Ubuntu 20.04 (Focal Fossa) repos as well for easy libcec4 installation
                   sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse" >> /etc/apt/sources.list'
                   sudo apt-get install -yq libudev-dev libp8-platform2 libp8-platform-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,47 +25,47 @@ jobs:
                       use-cross: false
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: aarch64-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: i686-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: arm-unknown-linux-gnueabi
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: armv7-unknown-linux-gnueabihf
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: mips-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: mips64-unknown-linux-gnuabi64
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: mips64el-unknown-linux-gnuabi64
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: mipsel-unknown-linux-gnu
                       use-cross: true
                       libcec: vendored-libcec
                       expected_libcec_abi: 6
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Not run in cross so that EXPECTED_LIBCEC_VERSION_MAJOR shows inside the test
                       libcec: vendored-libcec
@@ -73,14 +73,14 @@ jobs:
                     #
                     # libcec discovery with pkg config
                     #
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Important that we do not run cross so package install shows up
                       libcec: "libcec4"
                       libcec-dev: "libcec-dev=4*"
                       pkg-config: true
                       expected_libcec_abi: 4
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Important that we do not run cross so package install shows up
                       libcec: "libcec6"
@@ -91,7 +91,7 @@ jobs:
                     # libcec discovery without pkg config
                     # We set LD_LIBRARY_PATH and C_INCLUDE_PATH for compiler to find the preinstalled libcec
                     #
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Important that we do not run cross so package install shows up
                       libcec: "libcec4"
@@ -101,7 +101,7 @@ jobs:
                       additional_env:
                           LD_LIBRARY_PATH: "/usr/lib/x86_64-linux-gnu/"
                           C_INCLUDE_PATH: "/usr/include/libcec/"
-                    - os: ubuntu-22.04
+                    - os: ubuntu-latest
                       target: x86_64-unknown-linux-gnu
                       use-cross: false # Important that we do not run cross so package install shows up
                       libcec: "libcec6"
@@ -179,7 +179,7 @@ jobs:
                   args: --target ${{ matrix.job.target }} -vv
     lint:
         name: Lint
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,10 @@ jobs:
                   sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse" >> /etc/apt/sources.list'
                   sudo apt-get install -yq libudev-dev libp8-platform2 libp8-platform-dev
 
-                  apt show '${{ matrix.job.libcec }}'
+                  apt show '${{ matrix.job.libcec }}' || :
                   sudo apt install -yq '${{ matrix.job.libcec }}'
 
-                  apt show '${{ matrix.job.libcec-dev }}'
+                  apt show '${{ matrix.job.libcec-dev }}' || :
                   sudo apt install -yq '${{ matrix.job.libcec-dev }}'
             # additional build dependencies for non-cross builds with vendored libcec sources
             - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == 'Linux' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
                   set -ex
                   # introduce Ubuntu 20.04 (Focal Fossa) repos as well for easy libcec4 installation
                   sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse" >> /etc/apt/sources.list'
-                  sudo apt get update  # re-loads apt sources
+                  sudo apt-get update  # re-loads apt sources
                   sudo apt-get install -yq libudev-dev libp8-platform2 libp8-platform-dev
 
                   apt show '${{ matrix.job.libcec }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,13 @@ jobs:
                   set -ex
                   # introduce Ubuntu 20.04 (Focal Fossa) repos as well for easy libcec4 installation
                   sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse" >> /etc/apt/sources.list'
+                  sudo apt get update  # re-loads apt sources
                   sudo apt-get install -yq libudev-dev libp8-platform2 libp8-platform-dev
 
-                  apt show '${{ matrix.job.libcec }}' || :
+                  apt show '${{ matrix.job.libcec }}'
                   sudo apt install -yq '${{ matrix.job.libcec }}'
 
-                  apt show '${{ matrix.job.libcec-dev }}' || :
+                  apt show '${{ matrix.job.libcec-dev }}'
                   sudo apt install -yq '${{ matrix.job.libcec-dev }}'
             # additional build dependencies for non-cross builds with vendored libcec sources
             - if: ${{ startsWith(matrix.job.libcec, 'vendored') && !matrix.job.use-cross && runner.os == 'Linux' }}


### PR DESCRIPTION
ubuntu-latest is now alias to ubuntu-22.04

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/libcec-sys/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/libcec-sys/blob/master/CHANGELOG.md
-->
